### PR TITLE
include fnmatch

### DIFF
--- a/zindex.c
+++ b/zindex.c
@@ -9,6 +9,7 @@
 #include <stdint.h>
 #include <zstd.h>
 #include <pthread.h>
+#include <fnmatch.h>
 
 /*
    Compile (tested on ubuntu)


### PR DESCRIPTION
ISO C99 and later do not support implicit function declarations.